### PR TITLE
fix for multiple op instance used same variable instance address to j…

### DIFF
--- a/types/operations.go
+++ b/types/operations.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 
 	"github.com/denkhaus/bitshares/util"
 	"github.com/denkhaus/logging"
@@ -82,6 +83,10 @@ func (p *OperationEnvelope) UnmarshalJSON(data []byte) error {
 	descr := fmt.Sprintf("Operation %s", p.Type)
 
 	if op, ok := OperationMap[p.Type]; ok {
+
+		// fix for multiple op instance used same variable instance address to json.Unmarshal() when call GetAccountHistory() by pkrss
+		op = reflect.New(reflect.TypeOf(reflect.ValueOf(op).Elem().Interface())).Elem().Addr().Interface().(Operation)
+
 		p.Operation = op
 		if err := ffjson.Unmarshal(raw[1], p.Operation); err != nil {
 			logging.DDumpUnmarshaled(descr, raw[1])


### PR DESCRIPTION
fix for multiple op instance used same variable instance address to json.Unmarshal() when call GetAccountHistory()