### PR TITLE
Shutdown connection on broken TCP

### DIFF
--- a/api/wsclient.go
+++ b/api/wsclient.go
@@ -203,6 +203,9 @@ func (p *wsClient) receive() {
 			if err != io.EOF {
 				p.errors <- errors.Annotate(err, "DecodeReader")
 			}
+			if err == syscall.EPIPE {
+				break
+			}
 
 			continue
 		}
@@ -313,6 +316,9 @@ func (p *wsClient) Call(method string, args []interface{}) (*RPCCall, error) {
 		p.mutex.Lock()
 		delete(p.pending, call.Request.ID)
 		p.mutex.Unlock()
+		if err == syscall.EPIPE {
+			p.closing.Set()
+		}
 
 		return nil, errors.Annotate(err, "Encode [req]")
 	}

--- a/api/wsclient.go
+++ b/api/wsclient.go
@@ -203,10 +203,7 @@ func (p *wsClient) receive() {
 			if err != io.EOF {
 				p.errors <- errors.Annotate(err, "DecodeReader")
 			}
-			if err == syscall.EPIPE {
-				break
-			}
-
+			
 			continue
 		}
 


### PR DESCRIPTION
I see error sometimes:

> Call: Encode [req]: write tcp 172.18.0.15:57738->94.130.146.198:443: write: broken pipe

So to detect dead connection we need check error (broken pipe mean not possible to send data because it closed).
